### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-docs/apidoc
+docs/apidoc/
 tests/index.html
 tests/junit.xml
 tests/*.svg

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-recommonmark
-semantic_version==2.5.0
-Sphinx==1.4.6
+recommonmark==0.4.0
+semantic_version==2.6.0
 sphinx_rtd_theme==0.1.9
+steenzout.sphinx==1.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six==1.10.0
-steenzout.object==1.0.4
+steenzout.object==1.0.8

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         '': [
             'LICENSE', 'NOTICE.md', 'README.md'],
         'steenzout.barcode': [
-            'steenzout/barcode/fonts/*']
+            'fonts/*']
     },
     classifiers=__classifiers__,
     install_requires=requirements('requirements.txt'),

--- a/steenzout/__init__.py
+++ b/steenzout/__init__.py
@@ -17,7 +17,7 @@
 """steenzout namespace package."""
 
 try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
+except ImportError:
+    __import__('pkg_resources').declare_namespace(__name__)

--- a/steenzout/__init__.py
+++ b/steenzout/__init__.py
@@ -1,9 +1,23 @@
 # -*- coding: utf-8 -*-
-"""Github organization namespace package."""
+#
+# Copyright 2016 Pedro Salgado
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""steenzout namespace package."""
 
 try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
+    __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/steenzout/__init__.py
+++ b/steenzout/__init__.py
@@ -1,19 +1,4 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright 2016 Pedro Salgado
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 """steenzout namespace package."""
 
 try:

--- a/steenzout/barcode/metadata.py
+++ b/steenzout/barcode/metadata.py
@@ -27,6 +27,6 @@ __maintainer__ = 'Pedro Salgado'
 __maintainer_email__ = 'steenzout@ymail.com'
 __project__ = 'steenzout.barcode'
 __url__ = 'https://github.com/steenzout/python-barcode'
-__version__ = '1.0.0b2'
+__version__ = '1.0.0'
 
 __release__ = '{version}'.format(version=__version__)

--- a/steenzout/barcode/metadata.py
+++ b/steenzout/barcode/metadata.py
@@ -27,6 +27,6 @@ __maintainer__ = 'Pedro Salgado'
 __maintainer_email__ = 'steenzout@ymail.com'
 __project__ = 'steenzout.barcode'
 __url__ = 'https://github.com/steenzout/python-barcode'
-__version__ = '1.0.0'
+__version__ = '1.0.0-beta3'
 
 __release__ = '{version}'.format(version=__version__)

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,11 @@ commands =
 
 [testenv:docs]
 changedir = docs
+usedevelop = False
 deps = -rrequirements-docs.txt
 
 commands =
     make dummy
-    make apidoc
     make coverage
     make changes
     make html

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ pep8ignore =
 
 
 [testenv]
-usedevelop = False
+usedevelop = True
 deps =
     -rrequirements.txt
     -rrequirements-extra-cli.txt

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ pep8ignore =
 
 
 [testenv]
-usedevelop = True
+usedevelop = False
 deps =
     -rrequirements.txt
     -rrequirements-extra-cli.txt


### PR DESCRIPTION
- `1.0.0-beta3`
  - use [steenzout.sphinx==1.0.12](https://github.com/steenzout/python-sphinx/releases/tag/1.0.12) to generate documentation
  - fixed `setup.py` `package_data` values
